### PR TITLE
Expose the color scheme of the "Step" button in the project creation wizard as a reusable scheme

### DIFF
--- a/codenvy-ide-api/src/main/java/com/codenvy/ide/api/ui/theme/Style.java
+++ b/codenvy-ide-api/src/main/java/com/codenvy/ide/api/ui/theme/Style.java
@@ -18,9 +18,8 @@
 package com.codenvy.ide.api.ui.theme;
 
 /**
- * This class contains constants for style. Fields initialized from user preferences.
- * Static methods used for bridging with CssResources
- *
+ * This class contains constants for style. Fields initialized from user preferences. Static methods used for bridging with CssResources
+ * 
  * @author Evgen Vidolob
  */
 public class Style {
@@ -131,6 +130,14 @@ public class Style {
         return theme.getButtonColor();
     }
 
+    public static String getNotableButtonTopColor() {
+        return theme.getNotableButtonTopColor();
+    }
+
+    public static String getNotableButtonColor() {
+        return theme.getNotableButtonColor();
+    }
+
     public static String getInputBackground() {
         return theme.getInputBackground();
     }
@@ -163,7 +170,7 @@ public class Style {
         return theme.getEditorGutterColor();
     }
 
-    //syntax
+    // syntax
     public static String getEditorKeyWord() {
         return theme.getEditorKeyWord();
     }
@@ -273,6 +280,6 @@ public class Style {
     }
 
     public static String getMainMenuFontColor() {
-        return  theme.getMainMenuFontColor();
+        return theme.getMainMenuFontColor();
     }
 }

--- a/codenvy-ide-api/src/main/java/com/codenvy/ide/api/ui/theme/Theme.java
+++ b/codenvy-ide-api/src/main/java/com/codenvy/ide/api/ui/theme/Theme.java
@@ -18,7 +18,6 @@
 package com.codenvy.ide.api.ui.theme;
 
 /**
- *
  * @author Evgen Vidolob
  */
 public interface Theme {
@@ -154,4 +153,8 @@ public interface Theme {
     String getMainMenuBkgColor();
 
     String getMainMenuFontColor();
+
+    String getNotableButtonTopColor();
+
+    String getNotableButtonColor();
 }

--- a/codenvy-ide-api/src/main/resources/com/codenvy/ide/api/ui/style.css
+++ b/codenvy-ide-api/src/main/resources/com/codenvy/ide/api/ui/style.css
@@ -51,6 +51,11 @@
 @eval buttonTopColor com.codenvy.ide.api.ui.theme.Style.getButtonTopColor();
 @eval buttonColor com.codenvy.ide.api.ui.theme.Style.getButtonColor();
 
+/* notable button */
+@eval notableButtonTopColor com.codenvy.ide.api.ui.theme.Style.getNotableButtonTopColor();
+@eval notableButtonColor com.codenvy.ide.api.ui.theme.Style.getNotableButtonColor();
+
+
 /*input*/
 @eval inputBackground com.codenvy.ide.api.ui.theme.Style.getInputBackground();
 

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/theme/DarkTheme.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/theme/DarkTheme.java
@@ -340,4 +340,14 @@ public class DarkTheme implements Theme {
     public String getMainMenuFontColor() {
         return "#dbdbdb";
     }
+
+    @Override
+    public String getNotableButtonTopColor() {
+        return "#dbdbdb";
+    }
+
+    @Override
+    public String getNotableButtonColor() {
+        return "#2d6ba3";
+    }
 }

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/theme/LightTheme.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/theme/LightTheme.java
@@ -371,4 +371,14 @@ public class LightTheme implements Theme {
     public String getMainMenuFontColor() {
         return "#222222";
     }
+
+    @Override
+    public String getNotableButtonTopColor() {
+        return "#dbdbdb";
+    }
+
+    @Override
+    public String getNotableButtonColor() {
+        return "#2d6ba3";
+    }
 }

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/wizard/newproject/step/Step.ui.xml
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/wizard/newproject/step/Step.ui.xml
@@ -2,6 +2,8 @@
              xmlns:g='urn:import:com.google.gwt.user.client.ui'>
     <ui:style>
         @eval brColor com.codenvy.ide.api.ui.theme.Style.getWizardStepsBorderColor();
+        @eval stepBtnBgColor com.codenvy.ide.api.ui.theme.Style.getNotableButtonColor();
+        @eval stepBtnTextColor com.codenvy.ide.api.ui.theme.Style.getNotableButtonTopColor();
         .mainPanel{
             height: 42px;
             width: 100%;
@@ -16,7 +18,8 @@
             vertical-align: middle;
             text-align: center;
             border-radius: 3px;
-            background: none repeat scroll 0% 0% rgb(45, 107, 163);
+            background: none repeat scroll 0% 0% stepBtnBgColor;
+            color: stepBtnTextColor;
             border: 1px solid brColor;
             margin-top:  7px;
             line-height: 24px;


### PR DESCRIPTION
Rationale :
The white-on-blue style of the "step" button in the new project wizard is very noticeable, and, until now, very specific to this case.
Now, for the datasource plugin, we got UI design guidelines with one element with the same style.
We could either :
- separately set the style with the same values in our code
- expose the colors of this style as constants in the style.css file in codenvy-ide-api (but this means also define it in the Style and Theme classes in codenvy-ide-core)

I submit the code providing the latter. Would this not be possible, we cuold still resort to the former.
