### PR TITLE
IDEX-367 and IDEX-368 : Allow to use guide on client side for injecting ...

### DIFF
--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/DefaultChainedCodeAssistProcessor.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/DefaultChainedCodeAssistProcessor.java
@@ -1,0 +1,125 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web;
+
+import com.codenvy.ide.ext.web.html.editor.HTMLCodeAssistProcessor;
+import com.codenvy.ide.texteditor.api.CodeAssistCallback;
+import com.codenvy.ide.texteditor.api.TextEditorPartView;
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
+import com.codenvy.ide.texteditor.api.codeassistant.CompletionProposal;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Allows to chain code assist processor for the default given content type.
+ * It will delegate to sub processors.
+ *
+ * @author Florent Benoit
+ */
+public abstract class DefaultChainedCodeAssistProcessor implements CodeAssistProcessor {
+
+    /**
+     * HTML code assist processors.
+     */
+    private Set<? extends CodeAssistProcessor> codeAssistProcessors;
+
+    /**
+     * Default constructor.
+     */
+    public DefaultChainedCodeAssistProcessor(Set<? extends CodeAssistProcessor> codeAssistProcessors) {
+        this.codeAssistProcessors = codeAssistProcessors;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void computeCompletionProposals(TextEditorPartView view, int offset, CodeAssistCallback callback) {
+        if (codeAssistProcessors.size() > 0) {
+            final List<CompletionProposal> proposalList = new ArrayList<>();
+            for (CodeAssistProcessor processor : codeAssistProcessors) {
+                processor.computeCompletionProposals(view, offset, new CodeAssistCallback() {
+                    @Override
+                    public void proposalComputed(CompletionProposal[] processorProposals) {
+                        if (processorProposals == null || processorProposals.length == 0) {
+                            return;
+                        }
+
+                        proposalList.addAll(Arrays.asList(processorProposals));
+
+                    }
+                });
+            }
+            callback.proposalComputed(proposalList.toArray(new CompletionProposal[proposalList.size()]));
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public char[] getCompletionProposalAutoActivationCharacters() {
+        Set<Character> characters = new HashSet<>();
+        if (codeAssistProcessors.size() > 0) {
+            for (CodeAssistProcessor processor : codeAssistProcessors) {
+                char[] found = processor.getCompletionProposalAutoActivationCharacters();
+                if (found != null) {
+                    for (char c : found) {
+                        characters.add(c);
+                    }
+                }
+            }
+        }
+        char[] chars = new char[characters.size()];
+        int c = 0;
+        for (Character character : characters) {
+            chars[c] = character.charValue();
+            c++;
+        }
+        return chars;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getErrorMessage() {
+        String errorMessage = null;
+        if (codeAssistProcessors.size() > 0) {
+            for (CodeAssistProcessor processor : codeAssistProcessors) {
+                String processorErrorMessage = processor.getErrorMessage();
+                if (processorErrorMessage != null) {
+                    if (errorMessage == null) {
+                        errorMessage = processorErrorMessage;
+                    } else {
+                        errorMessage.concat(processorErrorMessage);
+                    }
+                }
+            }
+        }
+        return errorMessage;
+    }
+
+    /**
+     * @return injected processors.
+     */
+    public Set<? extends CodeAssistProcessor> getProcessors() {
+        return codeAssistProcessors;
+    }
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/AutoEditStrategyFactory.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/AutoEditStrategyFactory.java
@@ -1,0 +1,37 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.html.editor;
+
+import com.codenvy.ide.texteditor.api.AutoEditStrategy;
+import com.codenvy.ide.texteditor.api.TextEditorPartView;
+
+/**
+ * Allows to define a new AutoEditStrategy based on text editor and content type.
+ * @author Florent Benoit
+ */
+public interface AutoEditStrategyFactory {
+
+    /**
+     * Build a new instance
+     * @param textEditorPartView editor view
+     * @param contentType content type
+     * @return a new strategy
+     */
+    AutoEditStrategy build(TextEditorPartView textEditorPartView, String contentType);
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/DefaultCodeAssistProcessor.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/DefaultCodeAssistProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.html.editor;
+
+import com.codenvy.ide.ext.web.DefaultChainedCodeAssistProcessor;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.Set;
+
+/**
+ * Allows to chain code assist processor for the default given content type.
+ * It will delegate to sub processors.
+ *
+ * @author Florent Benoit
+ */
+@Singleton
+public class DefaultCodeAssistProcessor extends DefaultChainedCodeAssistProcessor {
+
+    /**
+     * HTML code assist processors.
+     */
+    @Inject(optional = true)
+    public DefaultCodeAssistProcessor(Set<HTMLCodeAssistProcessor> htmlCodeAssistProcessors) {
+        super(htmlCodeAssistProcessors);
+    }
+
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HTMLCodeAssistProcessor.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HTMLCodeAssistProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.html.editor;
+
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
+
+/**
+ * Marker interface for HTML.
+ * @author Florent Benoit
+ */
+public interface HTMLCodeAssistProcessor extends CodeAssistProcessor {
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HTMLEditorConfigurationProvider.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HTMLEditorConfigurationProvider.java
@@ -1,0 +1,52 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.html.editor;
+
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
+import com.google.inject.Inject;
+
+import javax.inject.Provider;
+import java.util.Set;
+
+/**
+ * Guice Provider for HTML Editor configuration.
+ * @author Florent Benoit
+ */
+
+public class HTMLEditorConfigurationProvider implements Provider<HtmlEditorConfiguration> {
+
+    /**
+     * Auto Edit strategies with HTML editor scope
+     */
+    @Inject(optional = true)
+    private Set<AutoEditStrategyFactory> autoEditStrategyFactories;
+
+    @Inject
+    private DefaultCodeAssistProcessor chainedCodeAssistProcessor;
+
+
+    /**
+     * Build a new instance of HtmlEditor Configuration
+     * @return
+     */
+    @Override
+    public HtmlEditorConfiguration get() {
+        return new HtmlEditorConfiguration(autoEditStrategyFactories, chainedCodeAssistProcessor);
+    }
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HtmlEditorConfiguration.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HtmlEditorConfiguration.java
@@ -2,7 +2,7 @@
  * CODENVY CONFIDENTIAL
  * __________________
  *
- * [2012] - [2013] Codenvy, S.A.
+ * [2012] - [2014] Codenvy, S.A.
  * All Rights Reserved.
  *
  * NOTICE:  All information contained herein is, and remains
@@ -17,19 +17,47 @@
  */
 package com.codenvy.ide.ext.web.html.editor;
 
+import com.codenvy.ide.collections.Collections;
+import com.codenvy.ide.collections.StringMap;
+import com.codenvy.ide.text.Document;
+import com.codenvy.ide.texteditor.api.AutoEditStrategy;
 import com.codenvy.ide.texteditor.api.TextEditorConfiguration;
 import com.codenvy.ide.texteditor.api.TextEditorPartView;
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
 import com.codenvy.ide.texteditor.api.parser.CmParser;
 import com.codenvy.ide.texteditor.api.parser.Parser;
 
 import javax.validation.constraints.NotNull;
+import java.util.Set;
 
 /**
- * The html css type editor configuration.
+ * The html type editor configuration.
  *
  * @author <a href="mailto:evidolob@exoplatform.com">Evgen Vidolob</a>
  */
 public class HtmlEditorConfiguration extends TextEditorConfiguration {
+
+    /**
+     * Auto edit factories.
+     */
+    private Set<AutoEditStrategyFactory> autoEditStrategyFactories;
+
+    /**
+     * Chained processor.
+     */
+    private DefaultCodeAssistProcessor defaultProcessor;
+
+    /**
+     * Build a new Configuration with the given set of strategies.
+     *
+     * @param autoEditStrategyFactories
+     *         the strategy factories
+     */
+    public HtmlEditorConfiguration(Set<AutoEditStrategyFactory> autoEditStrategyFactories,
+                                   DefaultCodeAssistProcessor defaultProcessor) {
+        this.autoEditStrategyFactories = autoEditStrategyFactories;
+        this.defaultProcessor = defaultProcessor;
+    }
 
     /** {@inheritDoc} */
     @Override
@@ -37,6 +65,46 @@ public class HtmlEditorConfiguration extends TextEditorConfiguration {
         CmParser parser = getParserForMime("text/html");
         parser.setNameAndFactory("html", new HtmlTokenFactory());
         return parser;
+    }
+
+
+    @Override
+    public StringMap<CodeAssistProcessor> getContentAssistantProcessors(@NotNull TextEditorPartView view) {
+        if (defaultProcessor.getProcessors() == null || defaultProcessor.getProcessors().size() == 0) {
+            return null;
+        }
+        StringMap<CodeAssistProcessor> map = Collections.createStringMap();
+        map.put(Document.DEFAULT_CONTENT_TYPE, defaultProcessor);
+        return map;
+    }
+
+
+    /**
+     * Adds strategy for Interpolation brace completion
+     *
+     * @param view
+     *         the source viewer to be configured by this configuration
+     * @param contentType
+     *         the content type for which the strategies are applicable
+     * @return
+     */
+    @Override
+    public AutoEditStrategy[] getAutoEditStrategies(TextEditorPartView view, String contentType) {
+        // Get super class strategy
+        AutoEditStrategy[] parentStrategy = super.getAutoEditStrategies(view, contentType);
+
+        // No injected strategies, go with default
+        if (autoEditStrategyFactories == null || autoEditStrategyFactories.size() == 0) {
+            return parentStrategy;
+        }
+
+        AutoEditStrategy[] strategies = new AutoEditStrategy[parentStrategy.length + autoEditStrategyFactories.size()];
+        System.arraycopy(parentStrategy, 0, strategies, 0, parentStrategy.length);
+        int i = parentStrategy.length;
+        for (AutoEditStrategyFactory strategyFactory : autoEditStrategyFactories) {
+            strategies[i++] = strategyFactory.build(view, contentType);
+        }
+        return strategies;
     }
 
 }

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HtmlEditorProvider.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/html/editor/HtmlEditorProvider.java
@@ -2,7 +2,7 @@
  * CODENVY CONFIDENTIAL
  * __________________
  *
- * [2012] - [2013] Codenvy, S.A.
+ * [2012] - [2014] Codenvy, S.A.
  * All Rights Reserved.
  *
  * NOTICE:  All information contained herein is, and remains
@@ -37,22 +37,29 @@ public class HtmlEditorProvider implements EditorProvider {
     private       Provider<CodenvyTextEditor> editorProvider;
     private final NotificationManager         notificationManager;
 
+    /**
+     * HTML editor configuration.
+     */
+    private Provider<HtmlEditorConfiguration> htmlEditorConfigurationProvider;
+
     /** @param documentProvider */
     @Inject
     public HtmlEditorProvider(DocumentProvider documentProvider,
                               Provider<CodenvyTextEditor> editorProvider,
-                              NotificationManager notificationManager) {
+                              NotificationManager notificationManager,
+                              Provider<HtmlEditorConfiguration> htmlEditorConfigurationProvider) {
         super();
         this.documentProvider = documentProvider;
         this.editorProvider = editorProvider;
         this.notificationManager = notificationManager;
+        this.htmlEditorConfigurationProvider = htmlEditorConfigurationProvider;
     }
 
     /** {@inheritDoc} */
     @Override
     public EditorPartPresenter getEditor() {
         CodenvyTextEditor textEditor = editorProvider.get();
-        textEditor.initialize(new HtmlEditorConfiguration(), documentProvider, notificationManager);
+        textEditor.initialize(htmlEditorConfigurationProvider.get(), documentProvider, notificationManager);
         return textEditor;
     }
 }

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/inject/WebModule.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/inject/WebModule.java
@@ -1,0 +1,43 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.inject;
+
+import com.codenvy.ide.api.extension.ExtensionGinModule;
+import com.codenvy.ide.ext.web.html.editor.HTMLEditorConfigurationProvider;
+import com.codenvy.ide.ext.web.html.editor.HtmlEditorConfiguration;
+import com.codenvy.ide.ext.web.js.editor.JsEditorConfiguration;
+import com.codenvy.ide.ext.web.js.editor.JsEditorConfigurationProvider;
+import com.google.gwt.inject.client.AbstractGinModule;
+import com.google.inject.Singleton;
+
+/**
+ * Adds custom binding for Editors.
+ * @author Florent Benoit
+ */
+@ExtensionGinModule
+public class WebModule extends AbstractGinModule {
+
+        /** {@inheritDoc} */
+        @Override
+        protected void configure() {
+            bind(HtmlEditorConfiguration.class).toProvider(HTMLEditorConfigurationProvider.class).in(Singleton.class);
+            bind(JsEditorConfiguration.class).toProvider(JsEditorConfigurationProvider.class).in(Singleton.class);
+        }
+
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/AutoEditStrategyFactory.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/AutoEditStrategyFactory.java
@@ -1,0 +1,37 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.js.editor;
+
+import com.codenvy.ide.texteditor.api.AutoEditStrategy;
+import com.codenvy.ide.texteditor.api.TextEditorPartView;
+
+/**
+ * Allows to define a new AutoEditStrategy based on text editor and content type.
+ * @author Florent Benoit
+ */
+public interface AutoEditStrategyFactory {
+
+    /**
+     * Build a new instance
+     * @param textEditorPartView editor view
+     * @param contentType content type
+     * @return a new strategy
+     */
+    AutoEditStrategy build(TextEditorPartView textEditorPartView, String contentType);
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/DefaultCodeAssistProcessor.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/DefaultCodeAssistProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.js.editor;
+
+import com.codenvy.ide.ext.web.DefaultChainedCodeAssistProcessor;
+import com.codenvy.ide.ext.web.html.editor.HTMLCodeAssistProcessor;
+import com.codenvy.ide.texteditor.api.CodeAssistCallback;
+import com.codenvy.ide.texteditor.api.TextEditorPartView;
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
+import com.codenvy.ide.texteditor.api.codeassistant.CompletionProposal;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Allows to chain code assist processor for a given content type.
+ * It will delegate to sub processors.
+ * @author Florent Benoit
+ */
+@Singleton
+public class DefaultCodeAssistProcessor extends DefaultChainedCodeAssistProcessor {
+
+    /**
+     * JS code assist processors.
+     */
+    @Inject(optional = true)
+    public DefaultCodeAssistProcessor(Set<JsCodeAssistProcessor> jsCodeAssistProcessors) {
+        super(jsCodeAssistProcessors);
+    }
+
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsCodeAssistProcessor.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsCodeAssistProcessor.java
@@ -1,0 +1,27 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.js.editor;
+
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
+
+/**
+ * @author Florent Benoit
+ */
+public interface JsCodeAssistProcessor extends CodeAssistProcessor {
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorConfiguration.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorConfiguration.java
@@ -18,13 +18,19 @@
 package com.codenvy.ide.ext.web.js.editor;
 
 import com.codenvy.ide.MimeType;
+import com.codenvy.ide.collections.Collections;
+import com.codenvy.ide.collections.StringMap;
+import com.codenvy.ide.text.Document;
+import com.codenvy.ide.texteditor.api.AutoEditStrategy;
 import com.codenvy.ide.texteditor.api.TextEditorConfiguration;
 import com.codenvy.ide.texteditor.api.TextEditorPartView;
+import com.codenvy.ide.texteditor.api.codeassistant.CodeAssistProcessor;
 import com.codenvy.ide.texteditor.api.parser.BasicTokenFactory;
 import com.codenvy.ide.texteditor.api.parser.CmParser;
 import com.codenvy.ide.texteditor.api.parser.Parser;
 
 import javax.validation.constraints.NotNull;
+import java.util.Set;
 
 /**
  * The css css type editor configuration.
@@ -33,6 +39,20 @@ import javax.validation.constraints.NotNull;
  */
 public class JsEditorConfiguration extends TextEditorConfiguration {
 
+
+    private Set<AutoEditStrategyFactory>      autoEditStrategyFactories;
+    private DefaultCodeAssistProcessor defaultProcessor;
+
+    /**
+     * Build a new Configuration with the given set of strategies.
+     * @param autoEditStrategyFactories the strategy factories
+     */
+    public JsEditorConfiguration(Set<AutoEditStrategyFactory> autoEditStrategyFactories,
+                                 DefaultCodeAssistProcessor defaultProcessor) {
+        this.autoEditStrategyFactories = autoEditStrategyFactories;
+        this.defaultProcessor = defaultProcessor;
+    }
+
     /** {@inheritDoc} */
     @Override
     public Parser getParser(@NotNull TextEditorPartView view) {
@@ -40,4 +60,42 @@ public class JsEditorConfiguration extends TextEditorConfiguration {
         parser.setNameAndFactory("javascript", new BasicTokenFactory());
         return parser;
     }
+
+
+
+    @Override public StringMap<CodeAssistProcessor> getContentAssistantProcessors(@NotNull TextEditorPartView view) {
+        if (defaultProcessor.getProcessors() == null || defaultProcessor.getProcessors().size() == 0) {
+            return null;
+        }
+        StringMap<CodeAssistProcessor> map = Collections.createStringMap();
+        map.put(Document.DEFAULT_CONTENT_TYPE, defaultProcessor);
+        return map;
+    }
+
+
+    /**
+     * Adds strategy for Interpolation brace completion
+     * @param view the source viewer to be configured by this configuration
+     * @param contentType the content type for which the strategies are applicable
+     * @return
+     */
+    @Override
+    public AutoEditStrategy[] getAutoEditStrategies(TextEditorPartView view, String contentType) {
+        // Get super class strategy
+        AutoEditStrategy[] parentStrategy = super.getAutoEditStrategies(view, contentType);
+
+        // No injected strategies, go with default
+        if (autoEditStrategyFactories == null || autoEditStrategyFactories.size() == 0) {
+            return parentStrategy;
+        }
+
+        AutoEditStrategy[] strategies = new AutoEditStrategy[parentStrategy.length + autoEditStrategyFactories.size()];
+        System.arraycopy(parentStrategy, 0, strategies, 0, parentStrategy.length);
+        int i = parentStrategy.length;
+        for (AutoEditStrategyFactory strategyFactory : autoEditStrategyFactories) {
+            strategies[i++] = strategyFactory.build(view, contentType);
+        }
+        return strategies;
+    }
+
 }

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorConfigurationProvider.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorConfigurationProvider.java
@@ -1,0 +1,51 @@
+/*
+ * CODENVY CONFIDENTIAL
+ *  __________________
+ *
+ *   [2014] Codenvy, S.A.
+ *   All Rights Reserved.
+ *
+ *  NOTICE:  All information contained herein is, and remains
+ *  the property of Codenvy S.A. and its suppliers,
+ *  if any.  The intellectual and technical concepts contained
+ *  herein are proprietary to Codenvy S.A.
+ *  and its suppliers and may be covered by U.S. and Foreign Patents,
+ *  patents in process, and are protected by trade secret or copyright law.
+ *  Dissemination of this information or reproduction of this material
+ *  is strictly forbidden unless prior written permission is obtained
+ *  from Codenvy S.A..
+ */
+
+package com.codenvy.ide.ext.web.js.editor;
+
+import com.google.inject.Inject;
+
+import javax.inject.Provider;
+import java.util.Set;
+
+/**
+ * Provider for HTML Editor configuration.
+ * @author Florent Benoit
+ */
+
+public class JsEditorConfigurationProvider implements Provider<JsEditorConfiguration> {
+
+    /**
+     * Auto Edit strategies
+     */
+    @Inject(optional = true)
+    private Set<AutoEditStrategyFactory> autoEditStrategyFactories;
+
+    @Inject
+    private DefaultCodeAssistProcessor chainedCodeAssistProcessor;
+
+
+    /**
+     * Build a new instance of JsEditor Configuration
+     * @return
+     */
+    @Override
+    public JsEditorConfiguration get() {
+        return new JsEditorConfiguration(autoEditStrategyFactories, chainedCodeAssistProcessor);
+    }
+}

--- a/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorProvider.java
+++ b/codenvy-ext-web/src/main/java/com/codenvy/ide/ext/web/js/editor/JsEditorProvider.java
@@ -37,22 +37,29 @@ public class JsEditorProvider implements EditorProvider {
     private       Provider<CodenvyTextEditor> editorProvider;
     private final NotificationManager         notificationManager;
 
+    /**
+     * JS editor configuration.
+     */
+    private Provider<JsEditorConfiguration> jsEditorConfigurationProvider;
+
     /** @param documentProvider */
     @Inject
     public JsEditorProvider(DocumentProvider documentProvider,
                             Provider<CodenvyTextEditor> editorProvider,
-                            NotificationManager notificationManager) {
+                            NotificationManager notificationManager,
+                            Provider<JsEditorConfiguration> jsEditorConfigurationProvider) {
         super();
         this.documentProvider = documentProvider;
         this.editorProvider = editorProvider;
         this.notificationManager = notificationManager;
+        this.jsEditorConfigurationProvider = jsEditorConfigurationProvider;
     }
 
     /** {@inheritDoc} */
     @Override
     public EditorPartPresenter getEditor() {
         CodenvyTextEditor textEditor = editorProvider.get();
-        textEditor.initialize(new JsEditorConfiguration(), documentProvider, notificationManager);
+        textEditor.initialize(jsEditorConfigurationProvider.get(), documentProvider, notificationManager);
         return textEditor;
     }
 }


### PR DESCRIPTION
...Code Assist Processor and Auto Edit Strategies

Thus plugins can provide code assist processors and auto edit strategies by only declaring new Provides (Singleton of their code assist processor or auto edit strategies) so it's quite simple to contribute completing stuff from external plugins to the HTML and JS editors
