### PR TITLE
Fix typo in constant name editorGutterColor

### DIFF
--- a/codenvy-ide-api/src/main/resources/com/codenvy/ide/api/ui/style.css
+++ b/codenvy-ide-api/src/main/resources/com/codenvy/ide/api/ui/style.css
@@ -68,7 +68,7 @@
 @eval editorDefaultFontColor com.codenvy.ide.api.ui.theme.Style.getEditorDefaultFontColor();
 @eval editorSelectionColor com.codenvy.ide.api.ui.theme.Style.getEditorSelectionColor();
 @eval editorInactiveSelectionColor com.codenvy.ide.api.ui.theme.Style.getEditorInactiveSelectionColor();
-@eval editoGutterColor com.codenvy.ide.api.ui.theme.Style.getEditorGutterColor();
+@eval editorGutterColor com.codenvy.ide.api.ui.theme.Style.getEditorGutterColor();
 
 /* Sizes */
 @def dividerThickness 1px;

--- a/codenvy-ide-core/src/main/resources/com/codenvy/ide/texteditor/Editor.css
+++ b/codenvy-ide-core/src/main/resources/com/codenvy/ide/texteditor/Editor.css
@@ -93,7 +93,7 @@
 
     .leftGutterNotification {
         width: 14px;
-        background-color: editoGutterColor;
+        background-color: editorGutterColor;
         text-align: right;
     }
 


### PR DESCRIPTION
I think it's a typo, if it's not then sorry !
