### PR TITLE
Display editor type and bindings in the info bar

### DIFF
--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/JsEditorConstants.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/JsEditorConstants.java
@@ -40,4 +40,16 @@ public interface JsEditorConstants extends Constants {
     @DefaultStringValue("Tab Size: ")
     String infoPaneTabSizeLabel();
 
+    @DefaultStringValue("Editor: ")
+    String infoPaneEditorLabel();
+
+    @DefaultStringValue("Key bindings: ")
+    String infoPaneKeybindingLabel();
+
+    @DefaultStringValue("Unknown")
+    String infoPanelUnknownEditorType();
+
+    @DefaultStringValue("Unknown")
+    String infoPanelUnknownKeybindings();
+
 }

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/editortype/EditorTypeRegistryImpl.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/editortype/EditorTypeRegistryImpl.java
@@ -63,6 +63,9 @@ public class EditorTypeRegistryImpl implements EditorTypeRegistry {
         if (item != null) {
             return item.getName();
         } else {
+            Log.warn(EditorTypeRegistryImpl.class,
+                     "Editor type not found: " + editorType
+                         + " - available ones are " + PrintMap.printMap(this.editorTypes));
             return null;
         }
     }
@@ -82,6 +85,11 @@ public class EditorTypeRegistryImpl implements EditorTypeRegistry {
 
         public EditorBuilder getEditorProvider() {
             return editorBuilder;
+        }
+
+        @Override
+        public String toString() {
+            return "<" + this.name + ", " + this.editorBuilder.getClass().getSimpleName() + ">";
         }
     }
 

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/infopanel/InfoPanel.ui.xml
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/infopanel/InfoPanel.ui.xml
@@ -51,6 +51,9 @@
             flex-shrink: 0; /* don't allow to shrink if there is not enough space */
             -webkit-flex-shrink: 0;
         }
+        .infoPanel-item-right {
+            margin-left: 1em;
+        }
 
         /* specific styles */
         .editorInfo {
@@ -77,6 +80,9 @@
         .rightPart {
             margin-right: 10px;
         }
+        .separator {
+            margin-right: 2em;
+        }
     </ui:style>
 
     <g:HTMLPanel addStyleNames="{style.editorInfo} {style.infoPanel-layout} {style.panelInfo}">
@@ -95,7 +101,12 @@
                 <g:InlineLabel ui:field="tabSize" addStyleNames="{style.infoPanel-item}" />
             </div>
             <div class="{style.rightPart}">
-                <g:InlineLabel ui:field="fileType" addStyleNames="{style.infoPanel-item}" />
+                <span class="{style.infoPanel-item}"><ui:text from="{constants.infoPaneEditorLabel}" /></span>
+                <g:InlineLabel ui:field="editorTypeValue" addStyleNames="{style.infoPanel-item}" />
+                <span class="{style.infoPanel-item} {style.infoPanel-item-right}"><ui:text from="{constants.infoPaneKeybindingLabel}" /></span>
+                <g:InlineLabel ui:field="keybindingsValue" addStyleNames="{style.infoPanel-item}" />
+                <span class="{style.separator}">&nbsp;</span>
+                <g:InlineLabel ui:field="fileType" addStyleNames="{style.infoPanel-item} {style.infoPanel-item-right}" />
             </div>
         </div>
     </g:HTMLPanel>

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/infopanel/InfoPanelFactory.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/infopanel/InfoPanelFactory.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2012-2014 Codenvy, S.A.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Codenvy, S.A. - initial API and implementation
+ *******************************************************************************/
+package com.codenvy.ide.jseditor.client.infopanel;
+
+import com.codenvy.ide.jseditor.client.texteditor.EmbeddedTextEditorPartView;
+
+/**
+ * Factory for {@link InfoPanel} instances.
+ * 
+ * @author "Mickaël Leduque"
+ */
+public interface InfoPanelFactory {
+
+    /**
+     * Creates an {@link InfoPanel}
+     * 
+     * @param editor the associated editor
+     * @return a new {@link InfoPanel} instance
+     */
+    InfoPanel create(EmbeddedTextEditorPartView editor);
+}

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/inject/JsEditorGinModule.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/inject/JsEditorGinModule.java
@@ -31,6 +31,7 @@ import com.codenvy.ide.jseditor.client.editortype.EditorTypeRegistry;
 import com.codenvy.ide.jseditor.client.editortype.EditorTypeRegistryImpl;
 import com.codenvy.ide.jseditor.client.filetype.FileTypeIdentifier;
 import com.codenvy.ide.jseditor.client.filetype.MultipleMethodFileIdentifier;
+import com.codenvy.ide.jseditor.client.infopanel.InfoPanelFactory;
 import com.codenvy.ide.jseditor.client.preference.EditorTypePreferencePresenter;
 import com.codenvy.ide.jseditor.client.preference.EditorTypePreferenceView;
 import com.codenvy.ide.jseditor.client.preference.EditorTypePreferenceViewImpl;
@@ -73,6 +74,9 @@ public class JsEditorGinModule extends AbstractGinModule {
 
         // bind the default editor
         bind(EditorProvider.class).annotatedWith(Names.named("defaultEditor")).to(DefaultEditorProvider.class);
+
+        // bind the info panel factory
+        install(new GinFactoryModuleBuilder().build(InfoPanelFactory.class));
     }
 
     // no real need to make it a singleton, it's a simple instantiation

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/texteditor/EditorWidget.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/texteditor/EditorWidget.java
@@ -10,9 +10,11 @@
  *******************************************************************************/
 package com.codenvy.ide.jseditor.client.texteditor;
 
-import com.codenvy.ide.jseditor.client.document.EmbeddedDocument;
-import com.codenvy.ide.jseditor.client.events.HasCursorActivityHandlers;
 import com.codenvy.ide.api.text.Region;
+import com.codenvy.ide.jseditor.client.document.EmbeddedDocument;
+import com.codenvy.ide.jseditor.client.editortype.EditorType;
+import com.codenvy.ide.jseditor.client.events.HasCursorActivityHandlers;
+import com.codenvy.ide.jseditor.client.keymap.Keymap;
 import com.google.gwt.event.dom.client.HasBlurHandlers;
 import com.google.gwt.event.dom.client.HasChangeHandlers;
 import com.google.gwt.event.dom.client.HasFocusHandlers;
@@ -98,4 +100,13 @@ public interface EditorWidget extends IsWidget, HasChangeHandlers, HasFocusHandl
      * @return the selected range
      */
     Region getSelectedRange();
+
+    /**
+     * Returns the editor type for this editor.
+     * 
+     * @return the editor type
+     */
+    EditorType getEditorType();
+
+    Keymap getKeymap();
 }

--- a/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/texteditor/EmbeddedTextEditorPartViewImpl.java
+++ b/codenvy-ide-jseditor/src/main/java/com/codenvy/ide/jseditor/client/texteditor/EmbeddedTextEditorPartViewImpl.java
@@ -11,13 +11,16 @@
 package com.codenvy.ide.jseditor.client.texteditor;
 
 
+import java.util.Collections;
+import java.util.List;
+
 import com.codenvy.ide.api.projecttree.generic.FileNode;
 import com.codenvy.ide.api.text.Region;
-import com.codenvy.ide.jseditor.client.JsEditorConstants;
 import com.codenvy.ide.jseditor.client.document.EmbeddedDocument;
 import com.codenvy.ide.jseditor.client.editorconfig.EmbeddedTextEditorConfiguration;
 import com.codenvy.ide.jseditor.client.filetype.FileTypeIdentifier;
 import com.codenvy.ide.jseditor.client.infopanel.InfoPanel;
+import com.codenvy.ide.jseditor.client.infopanel.InfoPanelFactory;
 import com.codenvy.ide.texteditor.selection.CursorModelWithHandler;
 import com.google.gwt.core.shared.GWT;
 import com.google.gwt.event.dom.client.ChangeHandler;
@@ -27,10 +30,6 @@ import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.SimplePanel;
-
-import javax.inject.Inject;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Implementation of the View part of the editors of the embedded kind.
@@ -58,11 +57,10 @@ public class EmbeddedTextEditorPartViewImpl<T extends EditorWidget> extends Comp
 
     private int                             tabSize     = 3;
 
-    @Inject
     public EmbeddedTextEditorPartViewImpl(final EditorWidgetFactory<T> editorWidgetFactory,
                                           final FileTypeIdentifier fileTypeIdentifier,
-                                          final JsEditorConstants constants) {
-        infoPanel = new InfoPanel(this, constants);
+                                          final InfoPanelFactory infoPanelFactory) {
+        infoPanel = infoPanelFactory.create(this);
 
         HTMLPanel panel = uibinder.createAndBindUi(this);
         initWidget(panel);
@@ -107,7 +105,11 @@ public class EmbeddedTextEditorPartViewImpl<T extends EditorWidget> extends Comp
         this.editor.setTabSize(this.tabSize);
 
         // set up infopanel
-        this.infoPanel.createDefaultState(this.editorModes.get(0), this.embeddedDocument.getLineCount(), this.editor.getTabSize());
+        this.infoPanel.createDefaultState(this.editorModes.get(0),
+                                          editor.getEditorType(),
+                                          editor.getKeymap(),
+                                          this.embeddedDocument.getLineCount(),
+                                          this.editor.getTabSize());
         this.editor.addCursorActivityHandler(this.infoPanel);
         this.editor.addBlurHandler(this.infoPanel);
         this.editor.addFocusHandler(this.infoPanel);


### PR DESCRIPTION
Add editor type and keybinding in info bar.
This will break compilation until I merge the matching changes in plugin-editor-codemirror and plugin-editor-orion.
