### PR TITLE
Fix #IDEUI-197 ability to style part icon

### DIFF
--- a/codenvy-ide-api/src/main/java/com/codenvy/ide/api/parts/AbstractPartPresenter.java
+++ b/codenvy-ide-api/src/main/java/com/codenvy/ide/api/parts/AbstractPartPresenter.java
@@ -14,7 +14,7 @@ import com.codenvy.ide.api.selection.Selection;
 import com.codenvy.ide.util.ListenerManager;
 import com.codenvy.ide.util.ListenerManager.Dispatcher;
 import com.google.gwt.user.client.ui.IsWidget;
-
+import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.annotation.Nullable;
@@ -25,6 +25,7 @@ import javax.validation.constraints.NotNull;
  * Abstract base implementation of all PartPresenter
  *
  * @author <a href="mailto:evidolob@exoplatform.com">Evgen Vidolob</a>
+ * @author Stéphane Daviet
  */
 public abstract class AbstractPartPresenter implements PartPresenter {
     private ListenerManager<PropertyListener> manager;
@@ -105,5 +106,11 @@ public abstract class AbstractPartPresenter implements PartPresenter {
     @Override
     public SVGResource getTitleSVGImage() {
         return null;
+    }
+
+    @Nullable
+    @Override
+    public SVGImage decorateIcon(SVGImage svgImage) {
+        return svgImage;
     }
 }

--- a/codenvy-ide-api/src/main/java/com/codenvy/ide/api/parts/PartPresenter.java
+++ b/codenvy-ide-api/src/main/java/com/codenvy/ide/api/parts/PartPresenter.java
@@ -15,6 +15,7 @@ import com.codenvy.ide.api.selection.Selection;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.IsWidget;
 
+import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 import javax.annotation.Nullable;
@@ -24,6 +25,7 @@ import javax.validation.constraints.NotNull;
  * Part is a main UI block of the IDE.
  *
  * @author <a href="mailto:nzamosenchuk@exoplatform.com">Nikolay Zamosenchuk</a>
+ * @author Stéphane Daviet
  */
 public interface PartPresenter extends Presenter {
     /** The property id for <code>getTitle</code>, <code>getTitleImage</code> and <code>getTitleToolTip</code>. */
@@ -56,6 +58,15 @@ public interface PartPresenter extends Presenter {
      */
     @Nullable
     SVGResource getTitleSVGImage();
+
+    /**
+     * Decorate the title SVG image of this part. A convenient method to be able to size, color or perform any CSS related styling
+     * operation.
+     * @param svgImage the title SVG image
+     * @return the image decorated, could be or not the same reference, no matter.
+     */
+    @Nullable
+    SVGImage decorateIcon(SVGImage svgImage);
 
     /**
      * Returns the widget to be displayed in the title of this part. If this value changes the part must fire a property listener event

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/part/PartStackPresenter.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/part/PartStackPresenter.java
@@ -15,12 +15,12 @@ import com.codenvy.ide.api.constraints.Constraints;
 import com.codenvy.ide.api.editor.EditorPartPresenter;
 import com.codenvy.ide.api.event.EditorDirtyStateChangedEvent;
 import com.codenvy.ide.api.mvp.Presenter;
-import com.codenvy.ide.api.parts.base.BasePresenter;
 import com.codenvy.ide.api.parts.PartPresenter;
 import com.codenvy.ide.api.parts.PartStack;
 import com.codenvy.ide.api.parts.PartStackView;
 import com.codenvy.ide.api.parts.PartStackView.TabItem;
 import com.codenvy.ide.api.parts.PropertyListener;
+import com.codenvy.ide.api.parts.base.BasePresenter;
 import com.codenvy.ide.collections.Array;
 import com.codenvy.ide.collections.Collections;
 import com.codenvy.ide.part.projectexplorer.ProjectExplorerPartPresenter;
@@ -34,7 +34,6 @@ import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import com.google.web.bindery.event.shared.EventBus;
-
 import org.vectomatic.dom.svg.ui.SVGImage;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
@@ -48,6 +47,7 @@ import java.util.Map;
  * user what component is currently active.
  *
  * @author Nikolay Zamosenchuk
+ * @author Stéphane Daviet
  */
 public class PartStackPresenter implements Presenter, PartStackView.ActionDelegate, PartStack {
 
@@ -155,9 +155,14 @@ public class PartStackPresenter implements Presenter, PartStackView.ActionDelega
 
         part.addPropertyListener(propertyListener);
         // include close button
-        SVGResource titleSVGImage = part.getTitleSVGImage();
+        SVGResource titleSVGResource = part.getTitleSVGImage();
+        SVGImage titleSVGImage = null;
+        if (titleSVGResource != null) {
+            titleSVGImage = part.decorateIcon(new SVGImage(titleSVGResource));
+        }
         TabItem tabItem =
-                view.addTabButton(titleSVGImage == null ? null : new SVGImage(titleSVGImage), part.getTitle(),
+                view.addTabButton(titleSVGImage,
+                                  part.getTitle(),
                                   part.getTitleToolTip(),
                                   part.getTitleWidget(), partsClosable);
         bindEvents(tabItem, part);

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/part/editor/EditorPartStackPresenter.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/part/editor/EditorPartStackPresenter.java
@@ -40,6 +40,7 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  * Perspectives and used to display Editors.
  *
  * @author Nikolay Zamosenchuk
+ * @author Stéphane Daviet
  */
 @Singleton
 public class EditorPartStackPresenter extends PartStackPresenter implements EditorPartStack, ShowListButtonClickHandler {
@@ -93,9 +94,16 @@ public class EditorPartStackPresenter extends PartStackPresenter implements Edit
         parts.add(part);
         part.addPropertyListener(propertyListener);
         // include close button
-        SVGResource titleSVGImage = part.getTitleSVGImage();
+        SVGResource titleSVGResource = part.getTitleSVGImage();
+        SVGImage titleSVGImage = null;
+        if (titleSVGResource != null) {
+            titleSVGImage = part.decorateIcon(new SVGImage(titleSVGResource));
+        }
         PartStackView.TabItem tabItem =
-                view.addTabButton(titleSVGImage == null ? null : new SVGImage(titleSVGImage), part.getTitle(), part.getTitleToolTip(), null,
+                view.addTabButton(titleSVGImage,
+                                  part.getTitle(),
+                                  part.getTitleToolTip(),
+                                  null,
                                   partsClosable);
 
         if (part instanceof TextEditorPresenter) {


### PR DESCRIPTION
Add a decorateIcon method to PartPresenter with a default
implementation in AbstractPartPresenter. It is called in addPart
method, both from PartStackPresenter and EditorPartStackPresenter
just after having get the SVGResource from getTitleSVGImage and
before setting up the icon on the part.
