### PR TITLE
Fix IDEUI-250 Move tab icons to the left

### DIFF
--- a/codenvy-ext-builder/src/main/resources/com/codenvy/ide/extension/builder/client/builder.css
+++ b/codenvy-ext-builder/src/main/resources/com/codenvy/ide/extension/builder/client/builder.css
@@ -26,7 +26,7 @@
 svg.partIcon {
     width: 14px;
     height: 14px;
-    float: right;
+    float: left;
     position: relative;
     top: 1px;
 }

--- a/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/runner.css
+++ b/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/runner.css
@@ -38,7 +38,7 @@
 svg.partIcon {
     width: 14px;
     height: 14px;
-    float: right;
+    float: left;
     position: relative;
     top: 1px;
 }

--- a/codenvy-ide-core/src/main/resources/com/codenvy/ide/notification/notification.css
+++ b/codenvy-ide-core/src/main/resources/com/codenvy/ide/notification/notification.css
@@ -104,7 +104,7 @@
 }
 
 .countLabel {
-    float: right;
+    float: left;
     margin-top: 3px;
     margin-left: 3px;
     padding: 0px 3px;


### PR DESCRIPTION
Event/builder/runner tab icons are now at the left of the label
instead of the right.
