### PR TITLE
Fix IDEUI-293 Enhance notification behaviour

### DIFF
--- a/codenvy-ide-api/src/main/java/com/codenvy/ide/api/notification/Notification.java
+++ b/codenvy-ide-api/src/main/java/com/codenvy/ide/api/notification/Notification.java
@@ -82,9 +82,9 @@ public final class Notification {
     private Array<NotificationObserver> observers;
 
     /**
-     * Create notification with message and type. Other parameters will be added with default values. This notification has got
-     * an unread state, a finished status. It will be a non-important message that does not delegate any actions in response to opening and
-     * closing of a notification.
+     * Create notification with message and type. Other parameters will be added with default values. This notification has got an unread
+     * state, a finished status. It will be a non-important message that does not delegate any actions in response to opening and closing of
+     * a notification.
      *
      * @param message
      *         notification's message
@@ -92,7 +92,23 @@ public final class Notification {
      *         notification's type
      */
     public Notification(@NotNull String message, @NotNull Type type) {
-        this(message, type, null, null);
+        this(message, type, FINISHED, null, null);
+    }
+
+    /**
+     * Create notification with message, type and status. Other parameters will be added with default values. This notification has got
+     * an unread state. It will be a non-important message that does not delegate any actions in response to opening and closing of a
+     * notification.
+     *
+     * @param message
+     *         notification's message
+     * @param type
+     *         notification's type
+     * @param status
+     *         notification's status
+     */
+    public Notification(@NotNull String message, @NotNull Type type, @NotNull Status status) {
+        this(message, type, status, null, null);
     }
 
     /**
@@ -144,6 +160,27 @@ public final class Notification {
     public Notification(@NotNull String message, @NotNull Type type, @Nullable OpenNotificationHandler openHandler,
                         @Nullable CloseNotificationHandler closeHandler) {
         this(message, type, false, openHandler, closeHandler);
+    }
+
+    /**
+     * Create notification with message, type, status and action delegates on opening and closing of a notification. Other parameters will
+     * be added with default values. This notification has got an unread state and makes it possible to delegate some action in response to
+     * opening and closing of a notification. It will be a non-important message.
+     *
+     * @param message
+     *         notification's message
+     * @param type
+     *         notification's type
+     * @param status
+     *         notification's status
+     * @param openHandler
+     *         delegate that provides some actions when opening notification
+     * @param closeHandler
+     *         delegate that provides some actions when closing notification
+     */
+    public Notification(@NotNull String message, @NotNull Type type, @NotNull Status status, @Nullable OpenNotificationHandler openHandler,
+                        @Nullable CloseNotificationHandler closeHandler) {
+        this(message, type, status, false, openHandler, closeHandler);
     }
 
     /**
@@ -219,6 +256,29 @@ public final class Notification {
     public Notification(@NotNull String message, @NotNull Type type, boolean important,
                         @Nullable OpenNotificationHandler openHandler, @Nullable CloseNotificationHandler closeHandler) {
         this(message, type, FINISHED, UNREAD, new Date(), important, openHandler, closeHandler);
+    }
+
+    /**
+     * Create notification with message, type, status, note about important this one and action delegates on opening and closing of a
+     * notification. Other parameters will be added with default values. This notification have got an unread state. This notification
+     * delegates some actions in response to opening and closing of a notification.
+     *
+     * @param message
+     *         notification's message
+     * @param type
+     *         notification's type
+     * @param status
+     *         notification's status
+     * @param important
+     *         note about important this notification
+     * @param openHandler
+     *         delegate that provides some actions when opening notification
+     * @param closeHandler
+     *         delegate that provides some actions when closing notification
+     */
+    public Notification(@NotNull String message, @NotNull Type type, @NotNull Status status, boolean important,
+                        @Nullable OpenNotificationHandler openHandler, @Nullable CloseNotificationHandler closeHandler) {
+        this(message, type, status, UNREAD, new Date(), important, openHandler, closeHandler);
     }
 
     /**
@@ -395,6 +455,27 @@ public final class Notification {
         this.openHandler = openHandler;
         this.closeHandler = closeHandler;
         this.observers = Collections.createArray();
+    }
+
+    public void update(String message, Type type, Status status, State state, Boolean important) {
+        if (message != null && !message.trim().isEmpty()) {
+            this.message = message;
+        }
+        if (type != null) {
+            this.type = type;
+        }
+        if (status != null) {
+            this.status = status;
+        }
+        if (state != null) {
+            this.state = state;
+        }
+        if (important != null) {
+            this.important = important;
+        }
+
+        this.time = new Date();
+        notifyObservers();
     }
 
     /** @return notification's message */

--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/notification/NotificationMessage.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/notification/NotificationMessage.java
@@ -105,9 +105,7 @@ public class NotificationMessage extends PopupPanel implements Notification.Noti
         iconPanel.setStyleName(resources.notificationCss().notificationMessage());
         mainPanel.addWest(iconPanel, 25);
 
-        changeProgress();
-
-        changeType();
+        changeIcon();
 
         SVGImage closeIcon = new SVGImage(resources.closePopup());
         closeIcon.getElement().setAttribute("class", resources.notificationCss().closePopupIcon());
@@ -119,6 +117,7 @@ public class NotificationMessage extends PopupPanel implements Notification.Noti
         });
         mainPanel.addEast(closeIcon, 38);
 
+        title = new HTML();
         changeMessage();
         title.setStyleName(resources.notificationCss().center());
         mainPanel.add(title);
@@ -175,14 +174,11 @@ public class NotificationMessage extends PopupPanel implements Notification.Noti
         if (!prevState.equals(notification)) {
             changeMessage();
 
-            changeProgress();
+            changeIcon();
 
             if (notification.isImportant()) {
                 show();
             }
-
-            changeType();
-
 
             prevState = notification.clone();
         }
@@ -191,20 +187,14 @@ public class NotificationMessage extends PopupPanel implements Notification.Noti
     /** Change message. */
     private void changeMessage() {
         //If notification message is formated HTML - need to display only plain text from it.
-        title = new HTML("<p>" + new HTML(notification.getMessage()).getText() + "</p>");
+        title.setHTML("<p>" + new HTML(notification.getMessage()).getText() + "</p>");
     }
 
-    /** Change progress feedback when needed. */
-    private void changeProgress() {
-        if (!notification.isFinished()) {
-            changeImage(resources.progress()).getElement().setAttribute("class", resources.notificationCss().progress());
-        } else {
-            hideTimer.schedule(DEFAULT_TIME);
-        }
-    }
-
-    /** Change item's content in response to change notification type. */
-    private void changeType() {
+    /**
+     * Change icon when needed (between progress one and warning/success/error ones). Also trigger timer if needed to auto-hide notification
+     * when it is finished.
+     */
+    private void changeIcon() {
         if (prevState != null) {
             if (prevState.isError()) {
                 mainPanel.removeStyleName(resources.notificationCss().error());
@@ -213,14 +203,20 @@ public class NotificationMessage extends PopupPanel implements Notification.Noti
             }
         }
 
-        if (notification.isWarning()) {
-            changeImage(resources.warning());
-            mainPanel.addStyleName(resources.notificationCss().warning());
-        } else if (notification.isError()) {
-            changeImage(resources.error());
-            mainPanel.addStyleName(resources.notificationCss().error());
+        if (!notification.isFinished()) {
+            changeImage(resources.progress()).getElement().setAttribute("class", resources.notificationCss().progress());
         } else {
-            changeImage(resources.success()).getElement().setAttribute("class", resources.notificationCss().success());
+            if (notification.isWarning()) {
+                changeImage(resources.warning());
+                mainPanel.addStyleName(resources.notificationCss().warning());
+            } else if (notification.isError()) {
+                changeImage(resources.error());
+                mainPanel.addStyleName(resources.notificationCss().error());
+            } else {
+                changeImage(resources.success()).getElement().setAttribute("class", resources.notificationCss().success());
+            }
+
+            hideTimer.schedule(DEFAULT_TIME);
         }
     }
 


### PR DESCRIPTION
Some bugs were introduced by commit 25d32d on this issue. The text was
no more updatable and the in progress icon was always overriden by the
success one. Fix all thi things.

Moreover, each setter notify the observers, triggering a sequence of
refresh. The update method has been added to update a bunch of
parameters in a row and notify observers after.
