### PR TITLE
Fix IDEUI-316 Trigger zombie runners

### DIFF
--- a/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/actions/RunAction.java
+++ b/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/actions/RunAction.java
@@ -61,7 +61,7 @@ public class RunAction extends Action {
         CurrentProject currentProject = appContext.getCurrentProject();
         if (currentProject != null) {
             e.getPresentation().setVisible(currentProject.getRunner() != null);
-            e.getPresentation().setEnabled(currentProject.getIsRunningEnabled() && !runController.isAnyAppRunning());
+            e.getPresentation().setEnabled(currentProject.getIsRunningEnabled() && !runController.isAnyAppLaunched());
         } else {
             e.getPresentation().setEnabledAndVisible(false);
         }

--- a/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/console/RunnerConsolePresenter.java
+++ b/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/console/RunnerConsolePresenter.java
@@ -215,7 +215,7 @@ public class RunnerConsolePresenter extends BasePresenter implements RunnerConso
         view.hideAppPreview();
     }
 
-    /** Should be called when current app is stopped. */
+    /** Should be called when current app is started. */
     public void onAppStarted(ApplicationProcessDescriptor processDescriptor) {
         appURL = RunnerUtils.getLink(processDescriptor, Constants.LINK_REL_WEB_URL) != null ? RunnerUtils.getLink(processDescriptor,
                                                                                                                   Constants


### PR DESCRIPTION
When launching an application, the Run button becomes disabled only
when the app is considered running, so you can click multiple times
before that and ‘launch’ multiple runners. They don't really work but
are like staying in background in the events view.

The new flag isAnyAppLaunched in RunController is now setted just after
launch and used to enable/disable RunAction, preventing multi-run
trigerring.
