### PR TITLE
Fix IDEUI-221 Better app health check

### DIFF
--- a/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.java
+++ b/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.java
@@ -133,6 +133,9 @@ public interface RunnerLocalizationConstant extends Messages {
     @Key("appStarted")
     String applicationStarted(String name);
 
+    @Key("appMaybeStarted")
+    String applicationMaybeStarted(String name);
+
     @Key("environmentCooking")
     String environmentCooking(String name);
 

--- a/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.properties
+++ b/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.properties
@@ -62,7 +62,8 @@ project.running.now = Project {0} is running now.
 launchingRunner = Launching runner for project <b>{0}</b>…
 environmentCooking = Preparing environment to run application <b>{0}</b> on…
 appStarting = Environment preparation done. Application <b>{0}</b> starting up…
-appStarted = Application <b>{0}</b> has been started.
+appStarted = Application <b>{0}</b> fully booted and reachable.
+appMaybeStarted = Application URL for <b>{0}</b> activated. Application may not yet be fully booted.
 startAppFailed = Application <b>{0}</b> has failed to start. If the application continues to fail, please contact support.
 
 getAppLogsFailed = Unable to retrieve the application logs from the runner.


### PR DESCRIPTION
Various enhancement on the app health check that was partly bugged:
- when the application URL is displayed after 30' if app health check
  can't determine if app is available, now a notification popup message
  is displayed and app panel is updated,
- if app health check succeeds, this fallback 30' timer is cancelled,
- app failure now triggers on necessary cleaning on the console.
