### PR TITLE
Fix IDEUI-299 Cancelled run reported as timeout

### DIFF
--- a/codenvy-ext-builder/src/main/resources/com/codenvy/ide/extension/builder/client/BuilderLocalizationConstant.properties
+++ b/codenvy-ext-builder/src/main/resources/com/codenvy/ide/extension/builder/client/BuilderLocalizationConstant.properties
@@ -22,7 +22,7 @@ control.clearBuilderConsole.description = Clear console
 messages.buildInProgress = Your account is configured for 1 build at a time.  You can not start a second build until the first finishes. \
   We are building project <b>{0}</b>.
 messages.buildFailed = The build of the project has failed.
-messages.buildCanceled = Application <b>{0}</b> on queue has been stopped due to timeout. Upgrade to get an always on builder.
+messages.buildCanceled = Application <b>{0}</b> has been canceled due to timeout. Upgrade your account to get an always on builder.
 messages.promptSaveFiles = Some files has been modified. Save changes?
 
 ##### Titles #####

--- a/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.properties
+++ b/codenvy-ext-runner/src/main/resources/com/codenvy/ide/extension/runner/client/RunnerLocalizationConstant.properties
@@ -74,7 +74,7 @@ stopAppFailed = Application <b>{0}</b> has failed to shutdown.
 
 appFailed = We are having trouble starting the runner and deploying application <b>{0}</b>. Either necessary files are missing or a fundamental configuration has changed.
 
-appCanceled = Application <b>{0}</b>has been shutdown due to timeout. Upgrade to get an always on runner.
+appCanceled = Application <b>{0}</b> has been cancelled.
 
 appUpdating = Updating server-side code of Extension <b>{0}</b>...
 appUpdated = Extension <b>{0}</b> has been updated.


### PR DESCRIPTION
All cancelled runs where badly reported as timeout ones whereas it can
also happens in other cases (queue eviction). The client can only
report that the run has been cancelled, waiting for richer status, it's
on the server side that the real cause will be logged. Mainly messages
fixes.
