### PR TITLE
IDEUI-334 When using invalid characters in project name, edit zone becomes green instead of yellow

### DIFF
--- a/codenvy-ide-ui/src/main/resources/com/codenvy/ide/ui/Styles.css
+++ b/codenvy-ide-ui/src/main/resources/com/codenvy/ide/ui/Styles.css
@@ -12,6 +12,7 @@
 input.inputError {
     border-color: #ffe400;
     box-shadow: 0 0 5px #ffe400;
+    outline-color: #ffe400;
 }
 
 .inputField {


### PR DESCRIPTION
https://jira.codenvycorp.com/browse/IDEUI-334
