### PR TITLE
Fix IDEUI-346 Time active still running after stop

### DIFF
--- a/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/run/RunController.java
+++ b/codenvy-ext-runner/src/main/java/com/codenvy/ide/extension/runner/client/run/RunController.java
@@ -990,6 +990,9 @@ public class RunController implements Notification.OpenNotificationHandler {
         if (clientStartTime == 0) {
             return null;
         }
+        if (!isAnyAppLaunched) {
+            return totalActiveTimeMetric;
+        }
         String humanReadable = StringUtils.timeSecToHumanReadable((System.currentTimeMillis() - clientStartTime) / 1000);
         totalActiveTimeMetric.setValue(humanReadable);
         return totalActiveTimeMetric;


### PR DESCRIPTION
Fix for IDEX-1443 introduce this bug. Now, when no runner is launched
(isAnyAppLaunched), the counter gives the latest time active value.
