### PR TITLE
Fix IDEX-1495 Import project notification on top

### DIFF
--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/wizard/project/importproject/ImportProjectNotificationSubscriberImpl.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/wizard/project/importproject/ImportProjectNotificationSubscriberImpl.java
@@ -48,7 +48,7 @@ public class ImportProjectNotificationSubscriberImpl implements ImportProjectNot
 
     @Override
     public void subscribe(String projectName) {
-        notification = new Notification(locale.importingProject(), Notification.Status.PROGRESS);
+        notification = new Notification(locale.importingProject(), Notification.Status.PROGRESS, true);
         subscribe(projectName, notification);
         notificationManager.showNotification(notification);
     }


### PR DESCRIPTION
Import project notification is now important and thus stays on top
until import is finished.
