### PR TITLE
Use message dialog instead of Window.alert()

### DIFF
--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/notification/NotificationManagerImpl.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/notification/NotificationManagerImpl.java
@@ -18,8 +18,9 @@ import com.codenvy.ide.api.parts.PartPresenter;
 import com.codenvy.ide.api.parts.base.BasePresenter;
 import com.codenvy.ide.collections.Array;
 import com.codenvy.ide.collections.Collections;
+import com.codenvy.ide.ui.dialogs.DialogFactory;
+import com.google.gwt.i18n.client.DateTimeFormat;
 import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
@@ -44,8 +45,10 @@ public class NotificationManagerImpl extends BasePresenter implements Notificati
                                                                       Notification.NotificationObserver,
                                                                       NotificationManagerView.ActionDelegate,
                                                                       NotificationMessageStack.ActionDelegate {
-    private static final String TITLE = "Events";
+    private static final DateTimeFormat DATA_FORMAT = DateTimeFormat.getFormat("hh:mm:ss");
+    private static final String         TITLE       = "Events";
     private NotificationManagerView  view;
+    private DialogFactory            dialogFactory;
     private NotificationContainer    notificationContainer;
     private NotificationMessageStack notificationMessageStack;
     private Array<Notification>      notifications;
@@ -53,15 +56,20 @@ public class NotificationManagerImpl extends BasePresenter implements Notificati
     /**
      * Create manager.
      *
+     * @param eventBus
      * @param view
+     * @param dialogFactory
+     * @param notificationContainer
      * @param notificationMessageStack
      */
     @Inject
     public NotificationManagerImpl(EventBus eventBus,
                                    NotificationManagerView view,
+                                   DialogFactory dialogFactory,
                                    final NotificationContainer notificationContainer,
                                    final NotificationMessageStack notificationMessageStack) {
         this.view = view;
+        this.dialogFactory = dialogFactory;
         this.notificationContainer = notificationContainer;
         this.view.setDelegate(this);
         this.view.setContainer(notificationContainer);
@@ -161,7 +169,8 @@ public class NotificationManagerImpl extends BasePresenter implements Notificati
         if (openHandler != null) {
             openHandler.onOpenClicked();
         } else {
-            Window.alert(notification.getMessage());
+            dialogFactory.createMessageDialog(notification.getType().toString(),
+                                              DATA_FORMAT.format(notification.getTime()) + " " + notification.getMessage(), null).show();
         }
     }
 

--- a/codenvy-ide-core/src/test/java/com/codenvy/ide/notification/NotificationManagerImplTest.java
+++ b/codenvy-ide-core/src/test/java/com/codenvy/ide/notification/NotificationManagerImplTest.java
@@ -12,6 +12,7 @@ package com.codenvy.ide.notification;
 
 import com.codenvy.ide.api.notification.Notification;
 import com.codenvy.ide.part.PartStackPresenter;
+import com.codenvy.ide.ui.dialogs.DialogFactory;
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.web.bindery.event.shared.EventBus;
 import com.googlecode.gwt.test.GwtModule;
@@ -45,6 +46,8 @@ public class NotificationManagerImplTest extends GwtTestWithMockito {
     @Mock
     private NotificationManagerView  view;
     @Mock
+    private DialogFactory            dialogFactory;
+    @Mock
     private NotificationContainer    notificationContainer;
     @Mock
     private NotificationMessageStack notificationMessageStack;
@@ -56,7 +59,7 @@ public class NotificationManagerImplTest extends GwtTestWithMockito {
 
     @Before
     public void disarm() {
-        manager = new NotificationManagerImpl(eventBus, view, notificationContainer, notificationMessageStack);
+        manager = new NotificationManagerImpl(eventBus, view, dialogFactory, notificationContainer, notificationMessageStack);
         manager.setPartStack(partStack);
         when(partStack.getActivePart()).thenReturn(manager);
         reset(view);


### PR DESCRIPTION
Use message dialog instead of Window.alert() when db-clicking on notification in 'Events' panel
