### PR TITLE
IDEX-1711 Fix tab items of LEFT/RIGHT panel shifted to the bottom when

### DIFF
--- a/codenvy-ide-core/src/main/java/com/codenvy/ide/part/PartStackViewImpl.java
+++ b/codenvy-ide-core/src/main/java/com/codenvy/ide/part/PartStackViewImpl.java
@@ -121,6 +121,12 @@ public class PartStackViewImpl extends ResizeComposite implements PartStackView 
     /** {@inheritDoc} */
     @Override
     public void setTabpositions(Array<Integer> partPositions) {
+        // if this method is called, we reset the top position in case the tabitem is added after a first display of the part stack
+        top = 0;
+        if (tabPosition == RIGHT) {
+            top -= 1;
+        }
+
         for (int pos = 0; pos < partPositions.size(); pos++) {
             int realPartPos = partPositions.get(pos);
             if (realPartPos < tabButtons.size()) {


### PR DESCRIPTION
using a constraint after a first draw of the panel

Task-Url: https://jira.codenvycorp.com/browse/IDEX-1711
